### PR TITLE
MAE-988: Fix error when adding new lineitem on PHP8

### DIFF
--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -507,7 +507,8 @@ ORDER BY  ps.id, pf.weight ;
         )
       );
       $contriParams['total_amount'] = $updatedAmount;
-      $contriParams['net_amount'] = $updatedAmount - CRM_Utils_Array::value('fee_amount', $updatedContribution, 0);
+      $feeAmount = CRM_Utils_Array::value('fee_amount', $updatedContribution, 0) ?: 0;
+      $contriParams['net_amount'] = $updatedAmount - $feeAmount;
       if ($taxAmount) {
         $contriParams['tax_amount'] = $taxAmount;
       }


### PR DESCRIPTION
## Overview

This PR applies the fix https://lab.civicrm.org/extensions/lineitemedit/-/merge_requests/73 to this fork, pending when the PR will be merged into the core extension.

See this [PR ](https://lab.civicrm.org/extensions/lineitemedit/-/merge_requests/73) for more information about the issue.