### PR TITLE
BTHAB-82: Increase supported line items to 50

### DIFF
--- a/CRM/Lineitemedit/Upgrader.php
+++ b/CRM/Lineitemedit/Upgrader.php
@@ -51,4 +51,17 @@ class CRM_Lineitemedit_Upgrader extends CRM_Lineitemedit_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Example: Run a couple simple queries.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   *
+   */
+  public function upgrade_2500() {
+    $this->ctx->log->info('Applying update 2500');
+    CRM_Lineitemedit_Util::generatePriceField(11, 50);
+    return TRUE;
+  }
+
 }

--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -888,7 +888,7 @@ ORDER BY  ps.id, pf.weight ;
       $pvIDs = array_keys($options);
       $form->add('select', 'add_item', ts('Add item'), ['' => '- select any price-field -'] + $options);
     }
-    for ($rowNumber = 0; $rowNumber <= 10; $rowNumber++) {
+    for ($rowNumber = 0; $rowNumber <= 50; $rowNumber++) {
       if (!empty($_POST['item_unit_price']) && !empty($_POST['item_unit_price'][$rowNumber])) {
         $submittedValues[] = $rowNumber;
       }
@@ -945,9 +945,11 @@ ORDER BY  ps.id, pf.weight ;
               'api.PriceField.get' => [
                 'sequential' => 1,
                 'price_set_id' => "\$value.id",
+                'options' => ['limit' => 0],
                 'api.PriceFieldValue.get' => [
                   'sequential' => 1,
-                  'price_field_id' => "\$value.id"
+                  'price_field_id' => "\$value.id",
+                  'options' => ['limit' => 0],
                 ],
               ],
             ]);
@@ -995,7 +997,7 @@ ORDER BY  ps.id, pf.weight ;
     return [$newPriceField['id'], $newPriceFieldValue['id']];
   }
 
-  public static function generatePriceField() {
+  public static function generatePriceField($start = 1, $end = 50) {
     $priceField = civicrm_api3('PriceField',
       'getsingle',
       [
@@ -1014,7 +1016,7 @@ ORDER BY  ps.id, pf.weight ;
     );
     $priceFieldValueParams = $priceFieldValue;
     unset($priceFieldValueParams['id'], $priceFieldValueParams['name'], $priceFieldValueParams['weight']);
-    for ($i = 1; $i <= 10; ++$i) {
+    for ($i = $start; $i <= $end; ++$i) {
       $params = array_merge($priceFieldParams, ['label' => ts('Additional Line Item') . " $i"]);
       $priceField = civicrm_api3('PriceField', 'get', $params)['values'];
       if (empty($priceField)) {

--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -201,7 +201,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
     if ($op == 'create' && empty($params['price_set_id'])) {
       $lineItemParams = [];
       $taxEnabled = (bool) Civi::settings()->get('invoicing');
-      for ($i = 0; $i <= 10; $i++) {
+      for ($i = 0; $i <= 50; $i++) {
         $lineItemParams[$i] = [];
         $notFound = TRUE;
         foreach (['item_label', 'item_financial_type_id', 'item_qty', 'item_unit_price', 'item_line_total', 'item_price_field_value_id'] as $attribute) {

--- a/templates/CRM/Lineitemedit/Form/AddLineItems.tpl
+++ b/templates/CRM/Lineitemedit/Form/AddLineItems.tpl
@@ -34,7 +34,7 @@
       </tr>
     {/foreach}
   {/if}
-  {section name='i' start=0 loop=10}
+  {section name='i' start=0 loop=50}
     {assign var='rowNumber' value=$smarty.section.i.index}
     <tr id="add-item-row-{$rowNumber}" class="line-item-row hiddenElement">
       <td>{$form.item_label.$rowNumber.html}</td>


### PR DESCRIPTION
## Overview
Previously only 10 line items can be added to a contribution from the contribution create/edit screen, we are extending this to 50.

## Before
Only 10 line items can be created
![image](https://user-images.githubusercontent.com/85277674/227564849-63437b7a-c54c-47dc-960b-a097812209b6.png)


## After
Upto 30 line items can be created
![afafaf](https://user-images.githubusercontent.com/85277674/227561277-c58f21fb-39f2-47fa-8cfd-de8fd64439a0.gif)


## Technical details

See :https://github.com/compucorp/lineitemedit/pull/3#issuecomment-1483213579

## Comment
This PR will also be sent to the module maintainer https://lab.civicrm.org/extensions/lineitemedit