### PR TITLE
BTHAB-188: Allow decimal quantity when editting line item

### DIFF
--- a/CRM/Lineitemedit/Form/Edit.php
+++ b/CRM/Lineitemedit/Form/Edit.php
@@ -61,7 +61,7 @@ class CRM_Lineitemedit_Form_Edit extends CRM_Core_Form {
     }
 
     if ($this->_isQuickConfig || empty($this->_priceFieldInfo['is_enter_qty'])) {
-      $this->_values['qty'] = (int) $this->_values['qty'];
+      $this->_values['qty'] = (float) $this->_values['qty'];
     }
   }
 
@@ -134,9 +134,9 @@ class CRM_Lineitemedit_Form_Edit extends CRM_Core_Form {
   public static function formRule($fields, $files, $self) {
     $errors = array();
 
-    if (!CRM_Utils_Rule::integer($fields['qty'])) {
+    if (!CRM_Utils_Rule::numeric($fields['qty'])) {
       if ($self->_isQuickConfig || $self->_priceFieldInfo['is_enter_qty'] == 0) {
-        $errors['qty'] = ts('Please enter a whole number quantity');
+        $errors['qty'] = ts('Please enter a numeric quantity');
       }
     }
 


### PR DESCRIPTION
## Overview
This PR allows users to input decimal quantities when editing a line item

## Before
Users can input decimal quantities when creating new line items, but cannot input decimal quantities when editing the line items.

![polik](https://github.com/compucorp/lineitemedit/assets/85277674/f7cf826c-5bd8-4b06-ad34-2b7023ae4dea)


## After
Users can now input decimal quantities when editing the line items.

![qqqqq](https://github.com/compucorp/lineitemedit/assets/85277674/ae6425a8-4f03-477e-ac82-8b17c42e2941)
