### PR TITLE
CIWEMB-423: Save line item raw total in data attribute

### DIFF
--- a/templates/CRM/Lineitemedit/Form/AddLineItems.tpl
+++ b/templates/CRM/Lineitemedit/Form/AddLineItems.tpl
@@ -190,6 +190,7 @@ CRM.$(function($) {
 
     total_amount = handleTotalAmountOnUpdate(total_amount);
     $('#line-total').text(CRM.formatMoney(total_amount));
+    $('#line-total').data('raw-total', total_amount).trigger('datachanged');
 
     return total_amount;
   }


### PR DESCRIPTION
This PR adds a new total_amount changed event that will be emitted every time the line item total amount is evaluated.

With this other extensions can listen for this event to know the total amount, without having to duplicate the total amount calculation logic.