### PR TITLE
MAE-1102: Fix Extension Installation And Upgrade Process

### DIFF
--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -1000,6 +1000,10 @@ ORDER BY  ps.id, pf.weight ;
     if (is_null($end)) {
       $end = Civi::settings()->get('line_item_number');
     }
+    $priceSet = self::getDefaultPriceSet();
+    if (empty($priceSet['financialtype.is_active'])) {
+      self::updateToFirstActiveFinancialType($priceSet['id']);
+    }
     $priceField = civicrm_api3('PriceField',
       'getsingle',
       [
@@ -1038,13 +1042,54 @@ ORDER BY  ps.id, pf.weight ;
   }
 
   public static function disableEnablePriceField($enable = FALSE) {
-    $priceSetID = civicrm_api3('PriceSet', 'getvalue', ['name' => 'default_contribution_amount', 'return' => 'id']);
-    $priceFields = civicrm_api3('PriceField', 'get', ['price_set_id' => $priceSetID, 'is_active' => !$enable])['values'];
+    $priceSet = self::getDefaultPriceSet();
+
+    $priceFields = civicrm_api3('PriceField', 'get', ['price_set_id' => $priceSet['id'], 'is_active' => !$enable])['values'];
+    if (empty($priceSet['financialtype.is_active'])) {
+      self::updateToFirstActiveFinancialType($priceSet['id'], array_column($priceFields, 'id'));
+    }
     foreach ($priceFields as $id => $value) {
       if ($value['name'] != 'contribution_amount') {
         civicrm_api3('PriceField', 'create', ['id' => $id, 'is_active' => $enable]);
       }
     }
+  }
+
+  private static function updateToFirstActiveFinancialType(int $priceSetId, array $priceFieldIds = []): void {
+    if (empty($priceSetId) && empty($priceFieldIds)) {
+      return;
+    }
+    if (empty($priceFieldIds)) {
+      $priceFieldIds = array_values(Civi\api4\PriceField::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('price_set_id', '=', $priceSetId)
+        ->execute()
+        ->column('id'));
+    }
+
+    $activeFinancialType = Civi\api4\FinancialType::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()
+      ->first();
+
+    Civi\api4\PriceSet::update(FALSE)
+      ->addValue('financial_type_id', $activeFinancialType['id'])
+      ->addWhere('id', '=', $priceSetId)
+      ->execute();
+    Civi\api4\PriceFieldValue::update(FALSE)
+      ->addValue('financial_type_id', $activeFinancialType['id'])
+      ->addWhere('price_field_id', 'IN', $priceFieldIds)
+      ->execute();
+  }
+
+  private static function getDefaultPriceSet(): array {
+    return Civi\api4\PriceSet::get(FALSE)
+      ->addSelect('priceset.id', 'financialtype.is_active')
+      ->addWhere('name', '=', 'default_contribution_amount')
+      ->addJoin('FinancialType', 'LEFT', NULL, ['financial_type_id', '=', 'financialtype.id'])
+      ->execute()
+      ->first();
   }
 
 }


### PR DESCRIPTION
## Overview
Currently there is a scenario that is described below in which the installation or upgrade process results in an error "Financial Type for Price Field Option is either disabled or does not exist". This pr fixes the error for this scenario.

During the installation or upgradation this extension tries to create or update price field and price field value entities. The price field value entity depends on a particular financial type. The price field value that this extension tries to create or update depends on **Donation** financial type. But the problem is that **Donation**  financial type can either be deleted or disabled as it is not a reserved financial type and in this case the civicrm throws the above mentioned error while saving the price field value entity.

This pr fixes the issue by changing the price field value creation in a way that price field value creation uses any first active financial type if **Donation** is disabled or deleted.