### PR TITLE
CIVIMM-212: Support Credit card contribution

### DIFF
--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -121,7 +121,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
       $lineItemParams = [];
       $taxEnabled = (bool) Civi::settings()->get('invoicing');
       
-      if (empty($params['item_label'])) {
+      if (!isset($params['item_label'])) {
         $params['item_label'] = CRM_Utils_Request::retrieve('item_label', 'String', NULL, FALSE, NULL, 'POST');
         $params['item_financial_type_id'] = CRM_Utils_Request::retrieve('item_financial_type_id', 'String', NULL, FALSE, NULL, 'POST');
         $params['item_qty'] = CRM_Utils_Request::retrieve('item_qty', 'String', NULL, FALSE, NULL, 'POST');
@@ -129,6 +129,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
         $params['item_line_total'] = CRM_Utils_Request::retrieve('item_line_total', 'String', NULL, FALSE, NULL, 'POST');
         $params['item_price_field_value_id'] = CRM_Utils_Request::retrieve('item_price_field_value_id', 'String', NULL, FALSE, NULL, 'POST');
         $params['item_tax_amount'] = CRM_Utils_Request::retrieve('item_tax_amount', 'String', NULL, FALSE, NULL, 'POST');
+        $params['tax_amount'] = 0; // previous tax can be removed since it will be recalculated below
       }
 
       for ($i = 0; $i <= Civi::settings()->get('line_item_number'); $i++) {

--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -120,6 +120,17 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
     if ($op == 'create' && empty($params['price_set_id'])) {
       $lineItemParams = [];
       $taxEnabled = (bool) Civi::settings()->get('invoicing');
+      
+      if (empty($params['item_label'])) {
+        $params['item_label'] = CRM_Utils_Request::retrieve('item_label', 'String', NULL, FALSE, NULL, 'POST');
+        $params['item_financial_type_id'] = CRM_Utils_Request::retrieve('item_financial_type_id', 'String', NULL, FALSE, NULL, 'POST');
+        $params['item_qty'] = CRM_Utils_Request::retrieve('item_qty', 'String', NULL, FALSE, NULL, 'POST');
+        $params['item_unit_price'] = CRM_Utils_Request::retrieve('item_unit_price', 'String', NULL, FALSE, NULL, 'POST');
+        $params['item_line_total'] = CRM_Utils_Request::retrieve('item_line_total', 'String', NULL, FALSE, NULL, 'POST');
+        $params['item_price_field_value_id'] = CRM_Utils_Request::retrieve('item_price_field_value_id', 'String', NULL, FALSE, NULL, 'POST');
+        $params['item_tax_amount'] = CRM_Utils_Request::retrieve('item_tax_amount', 'String', NULL, FALSE, NULL, 'POST');
+      }
+
       for ($i = 0; $i <= Civi::settings()->get('line_item_number'); $i++) {
         $lineItemParams[$i] = [];
         $notFound = TRUE;


### PR DESCRIPTION
## Overview
Preventing creating incomplete credit card contributions with incorrect tax and total value

## Before

https://github.com/user-attachments/assets/141e4c6f-f737-4c78-8cb6-f8308b4dbcf0

## After
<img width="817" alt="Screenshot 2024-10-02 at 10 04 02" src="https://github.com/user-attachments/assets/f2d07001-5bab-4d1b-a536-3b3ad8b8de9f">



## Technical Details

The extra line item parameters required to compute the appropriate line item amounts are not passed to the pre-hook for credit card contributions.

In this PR we now retrieve the necessary values from the form submitted valu.