### PR TITLE
MCSPRT-407: Use pricefieldvalue ID to index lineitems

### DIFF
--- a/CRM/Lineitemedit/Util.php
+++ b/CRM/Lineitemedit/Util.php
@@ -998,7 +998,7 @@ ORDER BY  ps.id, pf.weight ;
 
   public static function generatePriceField($start = 1, $end = null) {
     if (is_null($end)) {
-      $end = Civi::settings()->get('line_item_number');
+      $end = Civi::settings()->get('line_item_number') ?? 10;
     }
     $priceSet = self::getDefaultPriceSet();
     if (empty($priceSet['financialtype.is_active'])) {

--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -160,7 +160,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
           if (!empty($lineItemParams[$i]['line_total']) && !empty($lineItemParams[$i]['price_field_id'])) {
             $priceSetID = CRM_Core_DAO::getFieldValue('CRM_Price_BAO_PriceField', $lineItemParams[$i]['price_field_id'], 'price_set_id');
             if (!empty($params['line_item'][$priceSetID])) {
-              $params['line_item'][$priceSetID][$lineItemParams[$i]['price_field_id']] = $lineItemParams[$i];
+              $params['line_item'][$priceSetID][$lineItemParams[$i]['price_field_value_id']] = $lineItemParams[$i];
             }
           }
         }


### PR DESCRIPTION
## Overview

In CiviCRM core the contribution line items for a priceset array is indexed by the Price Field Value ID, but in the line item edit extension we attempt to update the line item array using the Price Field ID, this works in most cases of default CiviCRM installation, because the PriceField ID usually corresponds to the PriceFieldValueID. An example is seen below

```
{
    "id": 1,
    "price_field_id": 1,
    "name": "contribution_amount",
    "label": "Contribution Amount",
    "description": null,
    "help_pre": null,
    "help_post": null,
    "amount": 1,
    "count": null,
    "max_value": null,
    "weight": 1,
    "membership_type_id": null,
    "membership_num_terms": null,
    "is_default": false,
    "is_active": true,
    "financial_type_id": 1,
    "non_deductible_amount": 0,
    "visibility_id": 1
  },
  {
    "id": 2,
    "price_field_id": 2,
    "name": "additional_item_1",
    "label": "Additional Item 1",
    "description": null,
    "help_pre": null,
    "help_post": null,
    "amount": 1,
    "count": null,
    "max_value": null,
    "weight": 1,
    "membership_type_id": null,
    "membership_num_terms": null,
    "is_default": false,
    "is_active": true,
    "financial_type_id": 1,
    "non_deductible_amount": 0,
    "visibility_id": 1
  },
  {
    "id": 3,
    "price_field_id": 3,
    "name": "additional_item_2",
    "label": "Additional Item 2",
    "description": null,
    "help_pre": null,
    "help_post": null,
    "amount": 1,
    "count": null,
    "max_value": null,
    "weight": 1,
    "membership_type_id": null,
    "membership_num_terms": null,
    "is_default": false,
    "is_active": true,
    "financial_type_id": 1,
    "non_deductible_amount": 0,
    "visibility_id": 1
  },
```

But in custom installations or incases where these line items have been deleted then recreated with a different ID, this causes the logic to fail, ending up with same line item record bu different IDs, which will fail in DB insert due to unique key constraint.

<img width="834" alt="Screenshot 2024-11-13 at 14 46 41" src="https://github.com/user-attachments/assets/341d2f56-9681-4c96-a802-b5bf1be8096e">

In this PR we have made the necessary correction for the line item array to be accessed with the right key to avoid duplicate records

## Before
![aa1111ssseeeseseseses](https://github.com/user-attachments/assets/cc8aea26-0324-4195-9be3-a6750dbcfa9b)


## After
![ssseeeseseseses](https://github.com/user-attachments/assets/3d1b4068-4d7d-4918-b8c5-e00be398c655)

