### PR TITLE
CIVIPLMMSR-302: Avoid passing NULL to reference parameters

### DIFF
--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -122,13 +122,13 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
       $taxEnabled = (bool) Civi::settings()->get('invoicing');
       
       if (!isset($params['item_label'])) {
-        $params['item_label'] = CRM_Utils_Request::retrieve('item_label', 'String', NULL, FALSE, NULL, 'POST');
-        $params['item_financial_type_id'] = CRM_Utils_Request::retrieve('item_financial_type_id', 'String', NULL, FALSE, NULL, 'POST');
-        $params['item_qty'] = CRM_Utils_Request::retrieve('item_qty', 'String', NULL, FALSE, NULL, 'POST');
-        $params['item_unit_price'] = CRM_Utils_Request::retrieve('item_unit_price', 'String', NULL, FALSE, NULL, 'POST');
-        $params['item_line_total'] = CRM_Utils_Request::retrieve('item_line_total', 'String', NULL, FALSE, NULL, 'POST');
-        $params['item_price_field_value_id'] = CRM_Utils_Request::retrieve('item_price_field_value_id', 'String', NULL, FALSE, NULL, 'POST');
-        $params['item_tax_amount'] = CRM_Utils_Request::retrieve('item_tax_amount', 'String', NULL, FALSE, NULL, 'POST');
+        $params['item_label'] = CRM_Utils_Request::retrieve('item_label', 'String');
+        $params['item_financial_type_id'] = CRM_Utils_Request::retrieve('item_financial_type_id', 'String');
+        $params['item_qty'] = CRM_Utils_Request::retrieve('item_qty', 'String');
+        $params['item_unit_price'] = CRM_Utils_Request::retrieve('item_unit_price', 'String');
+        $params['item_line_total'] = CRM_Utils_Request::retrieve('item_line_total', 'String');
+        $params['item_price_field_value_id'] = CRM_Utils_Request::retrieve('item_price_field_value_id', 'String');
+        $params['item_tax_amount'] = CRM_Utils_Request::retrieve('item_tax_amount', 'String');
         $params['tax_amount'] = 0; // previous tax can be removed since it will be recalculated below
       }
 


### PR DESCRIPTION
## Overview

In this PR https://github.com/compucorp/lineitemedit/pull/15 we added support for credit card contributions, in the code we supply default values that are not necessary, in this PR we remove those default values, because some default values are to be passed as a reference in will not work in lower PHP version.

no visual changes.