### PR TITLE
CIVIMM-296: Fix Total Amount Calculation

### DIFF
--- a/templates/CRM/Lineitemedit/Form/AddLineItems.tpl
+++ b/templates/CRM/Lineitemedit/Form/AddLineItems.tpl
@@ -173,7 +173,15 @@ CRM.$(function($) {
     }
 
     let total_amount = 0;
-    if ($('input[id="total_amount"]').length) {
+
+    if (lineItemRows.length > 0) {
+      lineItemTable.rows.forEach(lineItem => {
+        if (lineItem.total_price) {
+          total_amount += parseFloat((lineItem.total_price.replace(thousandMarker,'') || 0));
+        }
+      });
+    }
+    else if ($('input[id="total_amount"]').length) {
       total_amount = parseFloat(($('input[id="total_amount"]').val().replace(thousandSeparator,'') || 0));
     }
 


### PR DESCRIPTION
## Overview
Currently the calculation for total amount is done in a way that we take the contribution total that has been calculated by civi and add the each line item's tax to it assuming that the contribution total from civi does not include tax but for some strange reason civi core calculates the total in a strange manner [i.e](https://github.com/civicrm/civicrm-core/blob/03e8fbbe2df0b1326cd659ad76adafd9cfbf2b09/CRM/Contribute/Form/Contribution.php#L492) civi removes the tax from contribution only if its related to a participant or membership otherwise the total amount already has the tax in it thus when we add line item tax for a participant or membership contribution it doubles up the vat.

This PR fixes the issue by calculating the total based solely on line items that is sum of each line item's price + each line item's vat.

## Before
<img width="1792" alt="Screenshot 2025-03-20 at 4 55 32 PM" src="https://github.com/user-attachments/assets/bb738297-1c74-4d25-87fd-69d300e01272" />

## After
<img width="1792" alt="Screenshot 2025-03-20 at 4 56 12 PM" src="https://github.com/user-attachments/assets/edf856e5-0c31-4d18-85f4-79b36de98582" />
