### PR TITLE
CIVIMM-327: Fix Tax Calculation For Contributions That Are Created Without Line Items

### DIFF
--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -120,8 +120,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
     if ($op == 'create' && empty($params['price_set_id'])) {
       $lineItemParams = [];
       $taxEnabled = (bool) Civi::settings()->get('invoicing');
-      
-      if (!isset($params['item_label'])) {
+      if (!isset($params['item_label']) && CRM_Utils_Request::retrieve('item_label', 'String') !== NULL) {
         $params['item_label'] = CRM_Utils_Request::retrieve('item_label', 'String');
         $params['item_financial_type_id'] = CRM_Utils_Request::retrieve('item_financial_type_id', 'String');
         $params['item_qty'] = CRM_Utils_Request::retrieve('item_qty', 'String');


### PR DESCRIPTION
## Overview
This pr fixes the tax calculation for contributions that are created without line items on ui like membership contribution, event registration contribution, contribution page submission etc. In [this](https://github.com/compucorp/lineitemedit/pull/15) PR we set the tax amount to 0 for recalculating it through submitted line items but the issue is if no line items are submitted like in the above mentioned scenarios then the tax amount remains 0 and in different email receipts the tax information is not shown at all.

## Before
No Tax information is shown in email receipts as the tax field in contribution is set to 0
<img width="1792" alt="Screenshot 2025-06-03 at 5 48 44 PM" src="https://github.com/user-attachments/assets/2e505037-391e-45ed-8d3e-36e3047698bc" />

## After
<img width="1792" alt="Screenshot 2025-06-03 at 5 48 51 PM" src="https://github.com/user-attachments/assets/75945cc0-05c4-4a04-8a16-0ab6b9874eea" />
