### PR TITLE
CIVIPLMMSR-708: Guard generatePriceField() in upgrade steps against queue-aborting exceptions

### DIFF
--- a/CRM/Lineitemedit/Upgrader.php
+++ b/CRM/Lineitemedit/Upgrader.php
@@ -42,7 +42,7 @@ class CRM_Lineitemedit_Upgrader extends CRM_Extension_Upgrader_Base {
       CRM_Lineitemedit_Util::generatePriceField();
     }
     catch (\Throwable $e) {
-      $this->ctx->log->info($e->getMessage());
+      $this->ctx->log->error('Failed to generate price fields in upgrade_2000: ' . $e->getMessage());
     }
     return TRUE;
   }
@@ -77,7 +77,7 @@ class CRM_Lineitemedit_Upgrader extends CRM_Extension_Upgrader_Base {
       CRM_Lineitemedit_Util::generatePriceField(11, 50);
     }
     catch (\Throwable $e) {
-      $this->ctx->log->info($e->getMessage());
+      $this->ctx->log->error('Failed to generate price fields in upgrade_2500: ' . $e->getMessage());
     }
     return TRUE;
   }

--- a/CRM/Lineitemedit/Upgrader.php
+++ b/CRM/Lineitemedit/Upgrader.php
@@ -42,7 +42,7 @@ class CRM_Lineitemedit_Upgrader extends CRM_Extension_Upgrader_Base {
       CRM_Lineitemedit_Util::generatePriceField();
     }
     catch (\Throwable $e) {
-      $this->ctx->log->error('Failed to generate price fields in upgrade_2000: ' . $e->getMessage());
+      $this->ctx->log->error('Failed to generate price fields in upgrade_2000: ' . $e->getMessage(), ['exception' => $e]);
     }
     return TRUE;
   }
@@ -77,7 +77,7 @@ class CRM_Lineitemedit_Upgrader extends CRM_Extension_Upgrader_Base {
       CRM_Lineitemedit_Util::generatePriceField(11, 50);
     }
     catch (\Throwable $e) {
-      $this->ctx->log->error('Failed to generate price fields in upgrade_2500: ' . $e->getMessage());
+      $this->ctx->log->error('Failed to generate price fields in upgrade_2500: ' . $e->getMessage(), ['exception' => $e]);
     }
     return TRUE;
   }

--- a/CRM/Lineitemedit/Upgrader.php
+++ b/CRM/Lineitemedit/Upgrader.php
@@ -34,7 +34,16 @@ class CRM_Lineitemedit_Upgrader extends CRM_Extension_Upgrader_Base {
    */
   public function upgrade_2000() {
     $this->ctx->log->info('Applying update 2000');
-    CRM_Lineitemedit_Util::generatePriceField();
+    // Guard the price-field generation: it makes several APIv4/v3 lookups that
+    // can throw during a large multi-version upgrade (e.g. before the default
+    // price set/field are resolvable). Log and continue so it does not abort the
+    // upgrade queue.
+    try {
+      CRM_Lineitemedit_Util::generatePriceField();
+    }
+    catch (\Throwable $e) {
+      $this->ctx->log->info($e->getMessage());
+    }
     return TRUE;
   }
 
@@ -60,7 +69,16 @@ class CRM_Lineitemedit_Upgrader extends CRM_Extension_Upgrader_Base {
    */
   public function upgrade_2500() {
     $this->ctx->log->info('Applying update 2500');
-    CRM_Lineitemedit_Util::generatePriceField(11, 50);
+    // Guard the price-field generation: it makes several APIv4/v3 lookups that
+    // can throw during a large multi-version upgrade (e.g. before the default
+    // price set/field are resolvable). Log and continue so it does not abort the
+    // upgrade queue.
+    try {
+      CRM_Lineitemedit_Util::generatePriceField(11, 50);
+    }
+    catch (\Throwable $e) {
+      $this->ctx->log->info($e->getMessage());
+    }
     return TRUE;
   }
 


### PR DESCRIPTION
## Overview

Makes the lineitemedit upgrade steps resilient so a large multi-version site upgrade doesn't abort part-way. Found during the CiviCRM core upgrade-crash investigation (CIVIPLMMSR-709 / civicrm/civicrm-core#36216).

## Before

`CRM_Lineitemedit_Util::generatePriceField()` performs several `civicrm_api3()` lookups (default price set, price field, price field values). The upgrade steps `upgrade_2000` and `upgrade_2500` call it directly with no try/catch. During a large multi-version upgrade any of those lookups can throw (e.g. before the default price set/field are resolvable), and the uncaught exception aborts the entire upgrade queue.

## After

The `generatePriceField()` calls in `upgrade_2000` and `upgrade_2500` are wrapped in try/catch — a failure is logged and the step returns `TRUE`, so the upgrade queue continues instead of halting. No behaviour change on the success path.

`install()` is intentionally left unguarded: a fresh install failing should surface, not be swallowed.

## Technical Details

```php
try {
  CRM_Lineitemedit_Util::generatePriceField(11, 50);
}
catch (\Throwable $e) {
  $this->ctx->log->info($e->getMessage());
}
return TRUE;
```

### Core overrides

N/A — extension code only.

## Comments

This branch is one of two the fix lands on — `master` and `2.8-patches` carry an identical `Upgrader.php`, and both feed CiviPlus (`master` → `7.x-4.x`, `2.8-patches` → `7.x-7.x`). To be validated against a real-DB clone as part of CIVIPLMMSR-708. Fix-only (no unit test): defensive guard around a bootstrap-timing hazard not reproducible in a healthy headless test DB.
